### PR TITLE
Add InvariantCulture for localisation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+.vs
 /packages/*
 /*.suo
 /*/bin

--- a/WrapYoutubeDl/AudioDownloader.cs
+++ b/WrapYoutubeDl/AudioDownloader.cs
@@ -159,7 +159,7 @@ namespace WrapYoutubeDl
             }
 
             // fire the process event
-            var perc = Convert.ToDecimal(Regex.Match(outLine.Data, @"\b\d+([\.,]\d+)?").Value);
+            var perc = Convert.ToDecimal(Regex.Match(outLine.Data, @"\b\d+([\.,]\d+)?").Value, System.Globalization.CultureInfo.InvariantCulture);
             if (perc > 100 || perc < 0)
             {
                 Console.WriteLine("weird perc {0}", perc);


### PR DESCRIPTION
I encountered a problem while using your library.
On one of the PCs, the format of the numbers was not configured in the same way (configure in French - France, so the separation was a comma).

To fix the problem, and avoid crashing the application, we had to add `CultureInfo.InvariantCulture` to not take into account the current culture.

Thanking you for your library.

*Translated from French.*